### PR TITLE
Discard the image return value that that is retuned by findContours in OpenCV 3.4 

### DIFF
--- a/object_detector.py
+++ b/object_detector.py
@@ -13,7 +13,7 @@ class detectorObj():
         mask = cv2.adaptiveThreshold(gray, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY_INV, 19, 5)
 
         # Find contours
-        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[-2:]
 
         #cv2.imshow("mask", mask)
         objects_contours = []


### PR DESCRIPTION
This change makes the project run with OpenCV 3.4 where [findContours](https://docs.opencv.org/3.4.0/d3/dc0/group__imgproc__shape.html#ga17ed9f5d79ae97bd4c7cf18403e1689a) returns three values instead of the expected two that newer versions return.

![image](https://user-images.githubusercontent.com/10342017/185102308-36bb5a08-a6aa-4269-b469-49dfa8a1a91e.png)

This solves the problem where the program fails with this error once it see a marker:
`ValueError: too many values to unpack (expected 2)`
